### PR TITLE
Add support for ForeignPerson and foreignId in Company Registration

### DIFF
--- a/portal/portal/src/main/java/com/superterminais/portal/dto/CompanyRegistrationRequest.java
+++ b/portal/portal/src/main/java/com/superterminais/portal/dto/CompanyRegistrationRequest.java
@@ -20,7 +20,8 @@ public class CompanyRegistrationRequest {
     private String name;
     private String cpf;
     
-    // We will add Foreign Person fields here later
+    // Foreign Person fields
+    private String foreignId;
 
     // Getters and Setters for all fields...
     
@@ -96,5 +97,13 @@ public class CompanyRegistrationRequest {
 
     public void setCpf(String cpf) {
         this.cpf = cpf;
+    }
+
+    public String getForeignId() {
+        return foreignId;
+    }
+
+     public void setForeignId(String foreignId) {
+        this.foreignId = foreignId;
     }
 }

--- a/portal/portal/src/main/java/com/superterminais/portal/model/ForeignPerson.java
+++ b/portal/portal/src/main/java/com/superterminais/portal/model/ForeignPerson.java
@@ -1,0 +1,34 @@
+package com.superterminais.portal.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("FOREIGN")
+public class ForeignPerson extends Company {
+
+    @Column(name = "corporate_name") // Razão Social
+    private String corporateName;
+
+    @Column(name = "foreign_id", unique = true) // Identificador Estrangeiro
+    private String foreignId;
+
+    // Getters and Setters
+
+    public String getCorporateName() {
+        return corporateName;
+    }
+
+    public void setCorporateName(String corporateName) {
+        this.corporateName = corporateName;
+    }
+
+    public String getForeignId() {
+        return foreignId;
+    }
+
+    public void setForeignId(String foreignId) {
+        this.foreignId = foreignId;
+    }
+}

--- a/portal/portal/src/main/java/com/superterminais/portal/repository/CompanyRepository.java
+++ b/portal/portal/src/main/java/com/superterminais/portal/repository/CompanyRepository.java
@@ -1,6 +1,7 @@
 package com.superterminais.portal.repository;
 
 import com.superterminais.portal.model.Company;
+import com.superterminais.portal.model.ForeignPerson;
 import com.superterminais.portal.model.LegalPerson;
 import com.superterminais.portal.model.NaturalPerson;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,5 +29,13 @@ public interface CompanyRepository extends JpaRepository<Company, UUID> {
      * @return an Optional containing the found NaturalPerson or an empty Optional if not found.
      */
     Optional<NaturalPerson> findByCpf(String cpf);
+
+    /**
+     * Finds a ForeignPerson entity by its unique foreign identifier.
+     *
+     * @param foreignId The foreign ID to search for.
+     * @return an Optional containing the found ForeignPerson or an empty Optional if not found.
+     */
+    Optional<ForeignPerson> findByForeignId(String foreignId);
 
 }

--- a/portal/portal/src/main/java/com/superterminais/portal/service/CompanyService.java
+++ b/portal/portal/src/main/java/com/superterminais/portal/service/CompanyService.java
@@ -3,6 +3,7 @@ package com.superterminais.portal.service;
 import com.superterminais.portal.dto.CompanyRegistrationRequest;
 import com.superterminais.portal.exception.RegistrationException;
 import com.superterminais.portal.model.Company;
+import com.superterminais.portal.model.ForeignPerson;
 import com.superterminais.portal.model.LegalPerson;
 import com.superterminais.portal.model.NaturalPerson;
 import com.superterminais.portal.model.enums.CompanyStatus;
@@ -32,6 +33,9 @@ public class CompanyService {
             case NATURAL_PERSON:
                 company = createNaturalPerson(request);
                 break;
+            case FOREIGN_PERSON:
+                company = createForeignPerson(request);
+                break;
             default:
                 throw new RegistrationException("Unsupported company type.");
         }
@@ -46,6 +50,19 @@ public class CompanyService {
         }
 
         return companyRepository.save(company);
+    }
+
+     private ForeignPerson createForeignPerson(CompanyRegistrationRequest request) {
+        // Validar se o Identificador Estrangeiro já existe
+        companyRepository.findByForeignId(request.getForeignId()).ifPresent(c -> {
+            throw new RegistrationException("Foreign ID already registered.");
+        });
+
+        ForeignPerson foreignPerson = new ForeignPerson();
+        foreignPerson.setCorporateName(request.getCorporateName());
+        foreignPerson.setForeignId(request.getForeignId());
+        populateCommonFields(foreignPerson, request);
+        return foreignPerson;
     }
 
     private LegalPerson createLegalPerson(CompanyRegistrationRequest request) {

--- a/portal/portal/src/main/resources/application.properties
+++ b/portal/portal/src/main/resources/application.properties
@@ -8,5 +8,7 @@ spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
 # Opcional: Mostra os comandos SQL gerados no console, útil para depuração
 spring.jpa.show-sql=true
 
-# spring.jpa.hibernate.ddl-auto=create
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
+# spring.jpa.hibernate.ddl-auto=update
+
+# file.upload-dir=./uploads


### PR DESCRIPTION
Add support for ForeignPerson and foreignId in Company Registration

## Description
This PR introduces support for handling **foreign companies** in the registration flow.  
The changes include the creation of a new `ForeignPerson` entity, the addition of a `foreignId` field in the company registration request, and logic updates in the `CompanyService`.

## Changes
- **feat:** Add `foreignId` field to `CompanyRegistrationRequest`.  
- **feat:** Create `ForeignPerson` entity with `corporateName` and `foreignId` fields.  
- **feat:** Add method to find `ForeignPerson` by `foreignId` and implement creation logic in `CompanyService`.  

## Motivation
This implementation enables proper handling and storage of foreign company data during the registration process, ensuring system compatibility with both local and foreign entities.  

## Checklist
- [x] Added new entity `ForeignPerson`.  
- [x] Updated DTOs and request objects with `foreignId`.  
- [x] Implemented logic to search and create `ForeignPerson` in `CompanyService`.  
- [ ] Added/updated unit tests (to be confirmed).  

## Branch
Target branch: `development`
